### PR TITLE
feat: mainpage 최근 등록 앨범, 노래, playlist 데이터 연결 및 쿼리 추가

### DIFF
--- a/TeamDive_Client/src/components/detail/MusicDetail.jsx
+++ b/TeamDive_Client/src/components/detail/MusicDetail.jsx
@@ -120,7 +120,7 @@ const MusicDetail = () => {
         if (!content.trim()) {alert('댓글을 입력해주세요'); return; }
 
         setNickname(loginUser.nickname);
-       
+        fetchReply();
         jaxios.post('/api/community/insertReply', {nickname, content},{params:{pagetype:'MUSIC', entityId: musicId, memberId: loginUser.memberId}})
         .then((result)=>{
             if(result.data.msg === 'yes'){

--- a/TeamDive_Client/src/components/frame/mainpage/LatestAlbums.jsx
+++ b/TeamDive_Client/src/components/frame/mainpage/LatestAlbums.jsx
@@ -1,26 +1,47 @@
 // src/components/LatestAlbums.jsx
-import React from 'react';
+import React, {useState, useEffect} from 'react';
 import styles from '../../../css/mainPage/latestAlbums.module.css';
 import { useNavigate } from 'react-router-dom';
+import axios from 'axios';
 
 
 const LatestAlbums = ({ album }) => {
 
     const navigate = useNavigate();
+    const [latestAlbumList, setLatestAlbumList] = useState([]);
+
+    useEffect(()=>{
+        const fetchLatestAlbum = async () => {
+            try {
+                const result = await axios.get('/api/music/latestAlbumList');
+                setLatestAlbumList(result.data.latestAlbumList);
+            } catch (err) {
+                console.error(err);
+            }
+        };
+    
+        fetchLatestAlbum();
+    },[]);
+
 
     return (
         <div className={styles.latestAlbums}>
-            {album.map(album => (
-                <div key={album.albumId} className={styles.albumItem}
-                    onClick={()=>{navigate(`/album/${album.albumId}`)}}
-                >
-                    <img src={album.image} alt={album.title} className={styles.albumCover} />
-                    <div className={styles.albumDetails}>
-                        <h4>{album.title}</h4>
-                        <small>{album.indate}</small>
-                    </div>
-                </div>
-            ))}
+            {
+                (latestAlbumList)?(
+                    latestAlbumList.map(album => (
+                        <div key={album.albumId} className={styles.albumItem}
+                            onClick={()=>{navigate(`/album/${album.albumId}`)}}
+                        >
+                            <img src={album.image} alt={album.title} className={styles.albumCover} />
+                            <div className={styles.albumDetails}>
+                                <h4>{album.title}</h4>
+                                <small>{album.indate.substring(0 ,10)}</small>
+                            </div>
+                        </div>
+                    ))
+                ):(<div>최신 등록앨범이 없습니다.</div>)
+            
+            }
         </div>
     );
 };

--- a/TeamDive_Client/src/components/frame/mainpage/LatestMusic.jsx
+++ b/TeamDive_Client/src/components/frame/mainpage/LatestMusic.jsx
@@ -1,25 +1,47 @@
 // src/components/LatestMusic.jsx
-import React from 'react';
+import React,{ useState, useEffect} from 'react';
 import styles from '../../../css/mainPage/latestMusic.module.css';
 import { useNavigate } from 'react-router-dom';
+import axios from 'axios';
 
 const LatestMusic = ({ music }) => {
 
     const navigate = useNavigate();
+    const [latestMusicList, setLatestMusicList] = useState([]);
 
+    useEffect(() => {
+        const fetchLatestMusic = async () => {
+            try {
+                const result = await axios.get('/api/music/latestMusicList');
+                setLatestMusicList(result.data.latestMusicList);
+            } catch (err) {
+                console.error(err);
+            }
+        };
+    
+        fetchLatestMusic();
+    }, []);
+    
+    
     return (
         <div className={styles.latestMusic}>
-            {music.map(music => (
-                <div key={music.musicId} className={styles.songItem}
-                    onClick={()=>{navigate(`/music/${music.musicId}`)}}
-                >
-                    <img src={music.image} alt={music.title} className={styles.albumCover} />
-                    <div className={styles.songDetails}>
-                        <h4>{music.title}</h4>
-                        <p>{music.artist}</p>
-                    </div>
-                </div>
-            ))}
+            {
+                (latestMusicList)?(
+                    latestMusicList.map((music,idx) => {
+                        return(
+                            <div key={music.musicId} className={styles.songItem}
+                                onClick={()=>{navigate(`/music/${music.musicId}`)}}
+                            >
+                                <img src={music.image} alt={music.title} className={styles.albumCover} />
+                                <div className={styles.songDetails}>
+                                    <h4>{music.title}</h4>
+                                    <p>{music.artist}</p>
+                                </div>
+                            </div>
+                        )
+                })
+                ):(<div>최신 등록곡이 없습니다.</div>)
+            }
         </div>
     );
 };

--- a/TeamDive_Client/src/components/frame/mainpage/RecommendedPlaylists.jsx
+++ b/TeamDive_Client/src/components/frame/mainpage/RecommendedPlaylists.jsx
@@ -1,27 +1,47 @@
 // src/components/RecommendedPlaylists.jsx
-import React from 'react';
+import React, {useState, useEffect} from 'react';
 import styles from '../../../css/mainPage/recommendedPlaylists.module.css';
 import { useNavigate } from 'react-router-dom';
+import axios from 'axios';
 
 const RecommendedPlaylists = ({ playList }) => {
 
     const navigate = useNavigate();
+    const [latestPlayList, setLatestPlayList] = useState([]);
+    
+    useEffect(() => {
+        const fetchLatestPlayList = async () => {
+            try {
+                const result = await axios.get('/api/music/latestPlayList');
+                setLatestPlayList(result.data.latestPlayList);
+            } catch (err) {
+                console.error(err);
+            }
+        };
+    
+        fetchLatestPlayList();
+    }, []);
 
     return (
         <div className={styles.playlists}>
-            {playList.map(playList => (
-                <div key={playList.playListId} className={styles.playlistItem}
-                    onClick={()=>{navigate(`/playList/${playList.playListId}`)}}
-                >
-                    <div className={styles.playlistCover}>
-                        {/* 플레이리스트 대표 이미지가 있다면 여기에 표시 */}
-                        <img src='/public/image/kakao_lion.png' alt={playList.title} />
-                    </div>
-                    <div className={styles.playlistDetails}>
-                        <h4>{playList.title}</h4>
-                    </div>
-                </div>
-            ))}
+            {
+                (latestPlayList)?(
+                    latestPlayList.map((playList, idx) => (
+                        <div key={playList.playListId} className={styles.playlistItem}
+                            onClick={()=>{navigate(`/playList/${playList.playListId}`)}}
+                        >
+                            <div className={styles.playlistCover}>
+                                {/* 플레이리스트 대표 이미지가 있다면 여기에 표시 */}
+                                <img src={playList.coverImage} alt={playList.title} />
+                            </div>
+                            <div className={styles.playlistDetails}>
+                                <h4>{playList.title}</h4>
+                            </div>
+                        </div>
+                    ))
+                ):(<div>추천 플레이 리스트가 없습니다.</div>)
+            
+            }
         </div>
     );
 };

--- a/src/main/java/com/himedia/projectteamdive/controller/MusicController.java
+++ b/src/main/java/com/himedia/projectteamdive/controller/MusicController.java
@@ -308,10 +308,28 @@ public class MusicController {
         HashMap<String,Object> map= ms.getTop3();
         return map;
     }
+    
+    // mainpage에서 최근 등록한 음악에 대한 정보 추출
+    @GetMapping("/latestMusicList")
+    public HashMap<String, Object> getLatestMusicList() {
+        HashMap<String, Object> map = ms.getLatestMusicList();
 
+        return map;
+    }
 
+    // mainpage에서 최근 등록된 앨범에 대한 정보 추출
+    @GetMapping("/latestAlbumList")
+    public HashMap<String, Object> getLatestAlbumList() {
+        HashMap<String, Object> map = ms.getLatestAlbumList();
+        return map;
+    }
 
-
+    // mainpage에서 최근 등록된 플레이 리스트에 대한 정보 추출
+    @GetMapping("/latestPlayList")
+    public HashMap<String, Object> getLatestPlayList() {
+        HashMap<String, Object> map = ms.getLatestPlayList();
+        return map;
+    }
 
 
 

--- a/src/main/java/com/himedia/projectteamdive/dto/PlaylistDto.java
+++ b/src/main/java/com/himedia/projectteamdive/dto/PlaylistDto.java
@@ -10,6 +10,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -25,6 +26,7 @@ public class PlaylistDto {
     private String memberId;
     private List<MusicDto> musicList;
     private boolean shayringyn;
+    private Timestamp indate;
 
     public PlaylistDto(Playlist playlist) {
         this.playlistId = playlist.getPlaylistId();
@@ -34,6 +36,7 @@ public class PlaylistDto {
         this.memberId = playlist.getMember().getMemberId();
         this.musicList = playlist.getMusicList().stream().map(MusicDto::new).collect(Collectors.toList());
         this.shayringyn = playlist.isShayringyn();
+        this.indate = playlist.getIndate();
     }
 
 }

--- a/src/main/java/com/himedia/projectteamdive/dto/RecommendationScore.java
+++ b/src/main/java/com/himedia/projectteamdive/dto/RecommendationScore.java
@@ -18,6 +18,6 @@ public class RecommendationScore {
     }
 
     public int getTotalLimit() {
-        return 20;
+        return 50;
     }
 }

--- a/src/main/java/com/himedia/projectteamdive/entity/Playlist.java
+++ b/src/main/java/com/himedia/projectteamdive/entity/Playlist.java
@@ -6,6 +6,7 @@ import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -41,6 +42,9 @@ public class Playlist {
     @ColumnDefault("false")
     private boolean shayringyn;
 
+    @Column(columnDefinition="DATETIME default now()")
+    private Timestamp indate;
+
     public void addMusic(Music music) {
         if (!this.musicList.contains(music)) {
             this.musicList.add(music);
@@ -52,7 +56,7 @@ public class Playlist {
             this.musicList.remove(music);
             music.getPlaylists().remove(this);
         }
-
     }
+
 
 }

--- a/src/main/java/com/himedia/projectteamdive/repository/AlbumRepository.java
+++ b/src/main/java/com/himedia/projectteamdive/repository/AlbumRepository.java
@@ -1,9 +1,13 @@
 package com.himedia.projectteamdive.repository;
 
 import com.himedia.projectteamdive.dto.AlbumDto;
+import com.himedia.projectteamdive.dto.MusicDto;
 import com.himedia.projectteamdive.entity.Album;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -15,4 +19,11 @@ public interface AlbumRepository extends JpaRepository<Album, Integer> {
     Album findByAlbumId(int albumId);
 
     List<AlbumDto> findByTitleContainingIgnoreCase(String s);
+
+    @Query("SELECT a.albumId FROM Album a ORDER BY a.indate DESC")
+    List<Integer> getLatestAlbumIds(Pageable pageable);
+
+    @Query("SELECT a FROM Album a WHERE a.albumId IN :albumId")
+    List<AlbumDto> getAlbumByIds(@Param("albumId")List<Integer> AlbumId);
+
 }

--- a/src/main/java/com/himedia/projectteamdive/repository/MusicRepository.java
+++ b/src/main/java/com/himedia/projectteamdive/repository/MusicRepository.java
@@ -3,6 +3,8 @@ package com.himedia.projectteamdive.repository;
 import com.himedia.projectteamdive.dto.MemberRecentMusicsDto;
 import com.himedia.projectteamdive.dto.MusicDto;
 import com.himedia.projectteamdive.entity.Music;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -35,6 +37,12 @@ public interface MusicRepository extends JpaRepository<Music, Integer> {
 
     @Query("SELECT m FROM Music m WHERE m.musicId IN :musicId")
     List<MusicDto> getMusicByIds(@Param("musicId") List<Integer> musicId);
+
+
+    @Query("SELECT m.musicId FROM Music m " +
+            "WHERE m.album IN (SELECT a FROM Album a ORDER BY a.indate DESC) ")
+    List<Integer> getLatestMusicIds(Pageable pageable);
+
 
 //    @Query("SELECT m FROM Music m WHERE m.musicId IN :ids ORDER BY m.tracknumber ASC")
 //    List<Music> findAllByMusicId(@Param("ids") List<Integer> ids);

--- a/src/main/java/com/himedia/projectteamdive/repository/PlaylistRepository.java
+++ b/src/main/java/com/himedia/projectteamdive/repository/PlaylistRepository.java
@@ -1,9 +1,14 @@
 package com.himedia.projectteamdive.repository;
 
+import com.himedia.projectteamdive.dto.AlbumDto;
 import com.himedia.projectteamdive.dto.PlaylistDto;
 import com.himedia.projectteamdive.entity.Playlist;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -13,4 +18,11 @@ public interface PlaylistRepository extends JpaRepository<Playlist, Integer> {
     List<PlaylistDto> findAllByMember_MemberId(String memberMemberId);
 
     Playlist findByPlaylistId(int playlistId);
+
+    @Query("SELECT p.playlistId FROM Playlist p WHERE p.shayringyn = true ORDER BY p.indate DESC")
+    List<Integer> getLatestPlayListIds(Pageable pageable);
+
+    @Query("SELECT p FROM Playlist p WHERE p.playlistId IN : playlistId")
+    List<PlaylistDto> getPlaylistByIds(List<Integer> latestPlayListIds);
+
 }

--- a/src/main/java/com/himedia/projectteamdive/service/MusicService.java
+++ b/src/main/java/com/himedia/projectteamdive/service/MusicService.java
@@ -433,4 +433,47 @@ public class MusicService {
         result.put("music",musicList);
         return result;
     }
+
+
+    public HashMap<String, Object> getLatestMusicList() {
+        HashMap<String, Object> result = new HashMap<>();
+
+        List<Integer> latestMusicIds = mr.getLatestMusicIds(PageRequest.of(0, 6));
+
+        if (latestMusicIds == null || latestMusicIds.isEmpty()) {
+            result.put("latestMusicList", new ArrayList<>()); // 빈 리스트 반환
+            return result;
+        }else {
+            List<MusicDto> latestMusicList = mr.getMusicByIds(latestMusicIds);
+            result.put("latestMusicList", latestMusicList);
+        }
+        return result;
+    }
+
+    public HashMap<String, Object> getLatestAlbumList() {
+        HashMap<String, Object> result = new HashMap<>();
+        List <Integer> latestAlbumIds = ar.getLatestAlbumIds(PageRequest.of(0,6));
+        if(latestAlbumIds == null || latestAlbumIds.isEmpty()) {
+            result.put("latestAlbumList", new ArrayList<>());
+            return result;
+        }else{
+            List<AlbumDto> latestAlbumList = ar.getAlbumByIds(latestAlbumIds);
+            result.put("latestAlbumList", latestAlbumList);
+        }
+        return result;
+
+    }
+
+    public HashMap<String, Object> getLatestPlayList() {
+        HashMap<String, Object> result = new HashMap<>();
+        List <Integer> latestPlayListIds = pr.getLatestPlayListIds(PageRequest.of(0,6));
+        if(latestPlayListIds == null || latestPlayListIds.isEmpty()) {
+            result.put("latestPlayListList", new ArrayList<>());
+            return result;
+        }else{
+            List<PlaylistDto> latestPlayListofList = pr.getPlaylistByIds(latestPlayListIds);
+            result.put("latestPlayListList", latestPlayListofList);
+        }
+        return result;
+    }
 }


### PR DESCRIPTION
feat: mainpage 최근 등록 앨범, 노래, playlist 데이터 연결 및 쿼리 추가
fix: main화면에 보일 playlist 추천란에는 단순히 sharingyn 이 true일 경우 보이고 최근등록한 순으로 나열되게 수정